### PR TITLE
Adding exception message to the error message

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -59,7 +59,7 @@ function process_start_script(start_script) {
         try {
             start_config = require(start_script);
         } catch(ex) {
-            throw new Error('Unable to load PM2 JSON configuration file (' + start_script + ')');
+            throw new Error('Unable to load PM2 JSON configuration file (' + start_script + ') due to the following error: ' + ex);
         }
 
         // PM2 app declarations can be an array or an object with an 'apps' node


### PR DESCRIPTION
If an error is caught during the load of PM2_SERVICE_SCRIPTS, instead of a generic error message, the message will contain the exception information. This will help to debug configuration errors like #30. This will solve issue #39.